### PR TITLE
Support tabbing between input fields in the mnemonic words dialog

### DIFF
--- a/xCore.UI/src/app/setup/create/confirm-mnemonic/confirm-mnemonic.component.html
+++ b/xCore.UI/src/app/setup/create/confirm-mnemonic/confirm-mnemonic.component.html
@@ -2,19 +2,19 @@
 	<form class="mx-auto d-flex align-content-center flex-wrap" [formGroup]="mnemonicForm">
 		<div class="form-group col-12">
 			<label for="word1">{{secretWordIndexGenerator.text1}}</label>
-			<input type="text" class="form-control" formControlName="word1" id="word1" [class.is-invalid]="formErrors.word1" [class.is-valid]="!formErrors.word1 && mnemonicForm.get('word1').valid" pInputText>
+			<input type="text" class="form-control" formControlName="word1" id="word1" #words appFocusable (keydown.tab)="focusNext($event)" [class.is-invalid]="formErrors.word1" [class.is-valid]="!formErrors.word1 && mnemonicForm.get('word1').valid" pInputText>
 			<div *ngIf="formErrors.word1" class="invalid-feedback">{{ formErrors.word1 }}</div>
 		</div>
 		<!-- /form-group -->
 		<div class="form-group col-12">
 			<label for="word2">{{secretWordIndexGenerator.text2}}</label>
-			<input type="text" class="form-control" formControlName="word2" id="word2" [class.is-invalid]="formErrors.word2" [class.is-valid]="!formErrors.word2 && mnemonicForm.get('word2').valid" pInputText>
+			<input type="text" class="form-control" formControlName="word2" id="word2" #words appFocusable (keydown.tab)="focusNext($event)" [class.is-invalid]="formErrors.word2" [class.is-valid]="!formErrors.word2 && mnemonicForm.get('word2').valid" pInputText>
 			<div *ngIf="formErrors.word2" class="invalid-feedback">{{ formErrors.word2 }}</div>
 		</div>
 		<!-- /form-group -->
 		<div class="form-group col-12">
 			<label for="word3">{{secretWordIndexGenerator.text3}}</label>
-			<input type="text" class="form-control" formControlName="word3" id="word3" [class.is-invalid]="formErrors.word3" [class.is-valid]="!formErrors.word3 && mnemonicForm.get('word3').valid" pInputText>
+			<input type="text" class="form-control" formControlName="word3" id="word3" #words appFocusable (keydown.tab)="focusNext($event)" [class.is-invalid]="formErrors.word3" [class.is-valid]="!formErrors.word3 && mnemonicForm.get('word3').valid" pInputText>
 			<div *ngIf="formErrors.word3" class="invalid-feedback">{{ formErrors.word3 }}</div>
 		</div>
 		<!-- /form-group -->

--- a/xCore.UI/src/app/setup/create/confirm-mnemonic/confirm-mnemonic.component.ts
+++ b/xCore.UI/src/app/setup/create/confirm-mnemonic/confirm-mnemonic.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter, ElementRef, QueryList, ViewChildren } from '@angular/core';
 import { FormGroup, Validators, FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ApiService } from '../../../shared/services/api.service';
@@ -33,6 +33,8 @@ export class ConfirmMnemonicComponent implements OnInit {
   public matchError = '';
   public isCreating: boolean;
   public isDarkTheme = false;
+
+  @ViewChildren('words') focusableInputs: QueryList<ElementRef>;
 
   formErrors = {
     word1: '',
@@ -165,5 +167,21 @@ export class ConfirmMnemonicComponent implements OnInit {
           this.isCreating = false;
         }
       );
+  }
+
+  private focusNext(event: KeyboardEvent) {
+    const elemCount = this.focusableInputs.length;
+
+    this.focusableInputs.forEach((focusableInput: any, index: number) => {
+      if (focusableInput.nativeElement.id === (event.target as any).id) {
+
+        const nextElIndex = index < elemCount - 1 ? index + 1 : 0;
+        const focusableArray = this.focusableInputs.toArray();
+        focusableArray[nextElIndex].nativeElement.focus();
+      }
+    });
+
+    event.stopPropagation();
+    event.preventDefault();
   }
 }


### PR DESCRIPTION
The request adds to the mnemonic words confirmation dialog the ability to switch between input fields using the TAB key.
No other dialog or interaction is enabled this way.