### PR TITLE
Change focusNext function visibility for html usage

### DIFF
--- a/xCore.UI/src/app/setup/create/confirm-mnemonic/confirm-mnemonic.component.ts
+++ b/xCore.UI/src/app/setup/create/confirm-mnemonic/confirm-mnemonic.component.ts
@@ -169,7 +169,7 @@ export class ConfirmMnemonicComponent implements OnInit {
       );
   }
 
-  private focusNext(event: KeyboardEvent) {
+  public focusNext(event: KeyboardEvent) {
     const elemCount = this.focusableInputs.length;
 
     this.focusableInputs.forEach((focusableInput: any, index: number) => {


### PR DESCRIPTION
Fixes the focuseNext function's visibility (private -> public, since required by the HTML) preventing the wallet from correctly building